### PR TITLE
Add FastAPI app Docker container for homework 03

### DIFF
--- a/homework_03/Dockerfile
+++ b/homework_03/Dockerfile
@@ -1,1 +1,14 @@
+# build: docker build -t homework_03 .
+# run: docker run -p 8000:8000 homework_03
 FROM python:3.12-bookworm
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/homework_03/app.py
+++ b/homework_03/app.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/ping/")
+async def ping() -> dict[str, str]:
+    return {"message": "pong"}

--- a/homework_03/requirements.txt
+++ b/homework_03/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add simple FastAPI application with /ping endpoint
- containerize app with Dockerfile and dependencies

## Testing
- `pytest testing/test_homework_03/test_app.py::test_build_and_run_app -q` *(fails: docker.errors.DockerException: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68b30083c58483239f87917aefd40592