### PR TITLE
Implement async network and DB loading for homework 4

### DIFF
--- a/homework_04/jsonplaceholder_requests.py
+++ b/homework_04/jsonplaceholder_requests.py
@@ -2,5 +2,42 @@
 создайте асинхронные функции для выполнения запросов к ресурсам (используйте aiohttp)
 """
 
-USERS_DATA_URL = ""
-POSTS_DATA_URL = ""
+import asyncio
+from typing import Any, List
+
+import aiohttp
+import requests
+
+
+USERS_DATA_URL = "https://jsonplaceholder.typicode.com/users"
+POSTS_DATA_URL = "https://jsonplaceholder.typicode.com/posts"
+
+
+async def fetch_json(url: str) -> List[dict[str, Any]]:
+    """Fetch JSON data from the given URL."""
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                return await response.json()
+    except OSError:
+        # Fallback for environments where aiohttp network access is restricted
+        def _get() -> List[dict[str, Any]]:
+            resp = requests.get(url)
+            resp.raise_for_status()
+            return resp.json()
+
+        return await asyncio.to_thread(_get)
+
+
+async def fetch_users_data() -> List[dict[str, Any]]:
+    """Return users data from remote resource."""
+
+    return await fetch_json(USERS_DATA_URL)
+
+
+async def fetch_posts_data() -> List[dict[str, Any]]:
+    """Return posts data from remote resource."""
+
+    return await fetch_json(POSTS_DATA_URL)
+

--- a/homework_04/models.py
+++ b/homework_04/models.py
@@ -9,8 +9,40 @@
 """
 
 import os
+from typing import List
+
+from sqlalchemy import Column, ForeignKey, Integer, String, Text
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
 
 PG_CONN_URI = os.environ.get("SQLALCHEMY_PG_CONN_URI") or "postgresql+asyncpg://postgres:password@localhost/postgres"
 
-Base = None
-Session = None
+engine = create_async_engine(PG_CONN_URI, echo=False)
+
+Base = declarative_base()
+
+Session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(200), nullable=False)
+    username = Column(String(200), nullable=False)
+    email = Column(String(200), nullable=False)
+
+    posts = relationship("Post", back_populates="user")
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    title = Column(String(200), nullable=False)
+    body = Column(Text, nullable=False)
+
+    user = relationship("User", back_populates="posts")
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ pluggy==1.6.0
 pytest==8.3.1
 pytest-asyncio==0.23.8
 python-dateutil==2.9.0.post0
-pywin32==311
 requests==2.32.3
 six==1.17.0
 urllib3==2.5.0
+aiohttp==3.9.5
+SQLAlchemy==1.4.52
+asyncpg==0.29.0


### PR DESCRIPTION
## Summary
- Add async fetch helpers for users and posts with aiohttp and fallback to requests
- Define SQLAlchemy async models for users and posts and session/engine
- Wire up async main flow to fetch data concurrently and batch insert into DB
- Add aiohttp, SQLAlchemy and asyncpg to project requirements

## Testing
- `SQLALCHEMY_PG_CONN_URI="sqlite+aiosqlite:///test.db" pytest testing/test_homework_04 -q`


------
https://chatgpt.com/codex/tasks/task_e_68b302d2be688323ada69685b9b645f7