### PR TITLE
Implement FastAPI app with templates and API

### DIFF
--- a/homework_05/templates/about.html
+++ b/homework_05/templates/about.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}About{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">About</h1>
+<p>This site is built with FastAPI for homework 05.</p>
+{% endblock %}

--- a/homework_05/templates/base.html
+++ b/homework_05/templates/base.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}Base Template{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <nav class="navbar navbar-expand-lg navbar-light bg-light">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('index') }}">Home</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+          <ul class="navbar-nav">
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('index') }}">Home</a>
+            </li>
+            <li class="nav-item">
+              <a class="nav-link" href="{{ url_for('about') }}">About</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container mt-4">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+</html>

--- a/homework_05/templates/index.html
+++ b/homework_05/templates/index.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block title %}Home{% endblock %}
+
+{% block content %}
+<h1 class="mb-4">Home Page</h1>
+<p>Welcome to the FastAPI application.</p>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,6 @@ urllib3==2.5.0
 aiohttp==3.9.5
 SQLAlchemy==1.4.52
 asyncpg==0.29.0
+fastapi==0.111.0
+uvicorn==0.30.1
+Jinja2==3.1.4


### PR DESCRIPTION
## Summary
- add FastAPI application with HTML and API routers
- style pages using Bootstrap base template and navigation
- include FastAPI dependencies

## Testing
- `pytest testing/test_homework_05/test_app.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b306915d2483238f6af9c35f96ba17