### PR TITLE
Add FastAPI app with Docker setup

### DIFF
--- a/homework_06/Dockerfile
+++ b/homework_06/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY homework_06/app /app/app
+
+CMD ["gunicorn", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "app.main:app", "--bind", "0.0.0.0:8000"]

--- a/homework_06/app/database.py
+++ b/homework_06/app/database.py
@@ -1,0 +1,17 @@
+import os
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://app:app@db:5432/app")
+
+engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+
+SessionLocal = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+
+Base = declarative_base()
+
+
+async def init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/homework_06/app/main.py
+++ b/homework_06/app/main.py
@@ -1,0 +1,45 @@
+from fastapi import Depends, FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import models
+from .database import SessionLocal, init_db
+
+app = FastAPI()
+templates = Jinja2Templates(directory="app/templates")
+
+
+async def get_db() -> AsyncSession:
+    async with SessionLocal() as session:
+        yield session
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_db()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def read_items(request: Request, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(models.Item))
+    items = result.scalars().all()
+    return templates.TemplateResponse("items.html", {"request": request, "items": items})
+
+
+@app.get("/add", response_class=HTMLResponse)
+async def add_item_form(request: Request):
+    return templates.TemplateResponse("add.html", {"request": request})
+
+
+@app.post("/add", response_class=HTMLResponse)
+async def create_item(
+    name: str = Form(...),
+    description: str | None = Form(None),
+    db: AsyncSession = Depends(get_db),
+):
+    item = models.Item(name=name, description=description)
+    db.add(item)
+    await db.commit()
+    return RedirectResponse(url="/", status_code=302)

--- a/homework_06/app/models.py
+++ b/homework_06/app/models.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String, Text
+
+from .database import Base
+
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False)
+    description = Column(Text)

--- a/homework_06/app/schemas.py
+++ b/homework_06/app/schemas.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel
+
+
+class ItemBase(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class ItemCreate(ItemBase):
+    pass
+
+
+class ItemRead(ItemBase):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/homework_06/app/templates/add.html
+++ b/homework_06/app/templates/add.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Add item</title>
+</head>
+<body>
+    <h1>Add item</h1>
+    <form action="/add" method="post">
+        <label>Name: <input type="text" name="name"></label><br>
+        <label>Description:<br><textarea name="description"></textarea></label><br>
+        <button type="submit">Create</button>
+    </form>
+</body>
+</html>

--- a/homework_06/app/templates/items.html
+++ b/homework_06/app/templates/items.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Items</title>
+</head>
+<body>
+    <h1>Items</h1>
+    <a href="/add">Add item</a>
+    <ul>
+    {% for item in items %}
+        <li><strong>{{ item.name }}</strong>: {{ item.description }}</li>
+    {% else %}
+        <li>No items yet</li>
+    {% endfor %}
+    </ul>
+</body>
+</html>

--- a/homework_06/docker-compose.yml
+++ b/homework_06/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: app
+      POSTGRES_PASSWORD: app
+      POSTGRES_DB: app
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  app:
+    build:
+      context: ..
+      dockerfile: homework_06/Dockerfile
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgresql+asyncpg://app:app@db:5432/app
+
+  nginx:
+    image: nginx:1.25
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - app
+
+volumes:
+  postgres_data:

--- a/homework_06/nginx.conf
+++ b/homework_06/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://app:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ asyncpg==0.29.0
 fastapi==0.111.0
 uvicorn==0.30.1
 Jinja2==3.1.4
+gunicorn==22.0.0
+python-multipart==0.0.9


### PR DESCRIPTION
## Summary
- implement FastAPI app with SQLAlchemy models and templates
- add Dockerfile and docker-compose with Postgres and Nginx
- update requirements for gunicorn and python-multipart

## Testing
- `pytest -q` (fails: docker.errors.DockerException)


------
https://chatgpt.com/codex/tasks/task_e_68b30a8a0f3c8323a877eff67fce756c