### PR TITLE
Add Codecov coverage upload to CI workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8
+        pip install flake8 pytest-cov
     - name: Install inner (homework-level) dependencies
       run: |
         for d in homework_* ; do
@@ -57,6 +57,11 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest testing -s -vv -r sxfE
+        pytest testing -s -vv -r sxfE --cov=. --cov-report=xml
       env:
         SQLALCHEMY_PG_CONN_URI: postgresql+asyncpg://postgres:secretpassword@localhost:5432/postgres
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- add pytest-cov to dependencies and collect coverage in CI
- upload coverage report to Codecov

## Testing
- `pytest --cov=. --cov-report=xml -q 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b31577dbd08323908283fdea2a9aeb