### PR TITLE
fix: make homework_03 app runnable as script

### DIFF
--- a/homework_03/Dockerfile
+++ b/homework_03/Dockerfile
@@ -11,4 +11,7 @@ COPY . .
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
+# Run the application using the module itself as an entrypoint.
+# This ensures that ``uvicorn`` is started via the Python interpreter which is
+# slightly more robust across different environments.
+CMD ["python", "app.py"]

--- a/homework_03/app.py
+++ b/homework_03/app.py
@@ -1,8 +1,24 @@
+"""Minimal FastAPI application used in tests.
+
+The application exposes a single endpoint ``/ping/`` that returns a JSON
+response ``{"message": "pong"}``.  The tests build a Docker image from this
+module and run it, therefore the module also contains an explicit entrypoint
+so it can be executed directly with ``python app.py``.
+"""
+
 from fastapi import FastAPI
+import uvicorn
+
 
 app = FastAPI()
 
 
 @app.get("/ping/")
 async def ping() -> dict[str, str]:
+    """Return a simple JSON response used by the tests."""
+
     return {"message": "pong"}
+
+
+if __name__ == "__main__":
+    uvicorn.run("app:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add main entrypoint to FastAPI example and document ping endpoint
- run container via `python app.py` for more robust startup

## Testing
- `pytest testing/test_homework_03/test_app.py::test_build_and_run_app -vv -s` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*

------
https://chatgpt.com/codex/tasks/task_e_68b31c47090483238bd8588d0ab47934