### PR TITLE
Support GitLab CI for master branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,7 @@ pytest:
     - pip install -r requirements-dev.txt
     - pytest
   rules:
-    - if: '$CI_COMMIT_BRANCH == "main"'
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "master"'
       when: on_success
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: manual


### PR DESCRIPTION
## Summary
- Run GitLab tests automatically on main/master branches
- Allow manual pipeline execution for merge requests

## Testing
- `pip install -r requirements-dev.txt`
- `pytest` *(fails: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68bc300b360883239d65fae20f5c87d9